### PR TITLE
Feature/16 unify image and document prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ AI routing and credentials are managed by WordPress; this plugin focuses on prom
 - **WordPress AI & Connectors**: Uses the site’s configured AI connectors
 - **Compatible with Tainacan 1.0+**: Uses the Pages and Admin Form Hooks APIs
 - **Smart cache**: Caching with manual clear from settings
-- **Custom prompts**: Default prompts and per-collection overrides
+- **Custom prompts**: One default analysis prompt plus per-collection overrides
+- **Prompt templates**: Suggested prompt templates in AI Tools that can be copied into the default prompt
 - **Metadata mapping**: Map AI-extracted fields to Tainacan metadata (supports “Fill fields” workflows)
 - **EXIF extraction**: Optional EXIF extraction from images (when enabled and supported by the server)
 - **PDF support**: Text extraction and optional visual analysis for PDFs (depends on server extensions and the configured connector)
@@ -108,7 +109,7 @@ When preparing a release for WordPress.org:
 ## Usage
 
 1. Ensure AI connectors are set up in **Settings → Connectors**
-2. Optionally adjust default prompts under **Tainacan → AI Tools** and per-collection prompts on each collection's edition form
+2. Optionally adjust the default prompt (and templates) under **Tainacan → AI Tools** and per-collection prompts on each collection's edition form
 3. Edit a Tainacan item with an attached document
 4. In the **AI Metadata Extractor** section, click **Analyze Document**
 5. Review results and fill metadata (manually or using the provided actions)
@@ -148,6 +149,7 @@ tainacan-ai/
 │   ├── API.php             # REST API endpoints
 │   ├── CollectionPrompts.php   # Post meta + metadata for mapping UI
 │   ├── CollectionFormHook.php  # Per-collection prompts on edition form
+│   ├── PromptTemplates.php     # Suggested prompt templates for admin UI
 │   ├── ExifExtractor.php
 │   ├── CoreAI.php              # WordPress AI client integration
 │   ├── CoreAIRequestLogging.php

--- a/includes/AdminPage.php
+++ b/includes/AdminPage.php
@@ -92,6 +92,7 @@ class AdminPage extends \Tainacan\Pages {
         wp_localize_script('tainacan-ai-admin', 'TainacanAIAdmin', [
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('tainacan_ai_admin_nonce'),
+            'promptTemplates' => PromptTemplates::get_templates(),
             'texts' => [
                 'error' => __('Something went wrong. Please try again.', 'tainacan-ai'),
                 'clearing' => __('Clearing cache...', 'tainacan-ai'),
@@ -99,6 +100,7 @@ class AdminPage extends \Tainacan\Pages {
                 'saving' => __('Saving...', 'tainacan-ai'),
                 'saved' => __('Saved successfully!', 'tainacan-ai'),
                 'loading' => __('Loading...', 'tainacan-ai'),
+                'confirmReplacePromptTemplate' => __('Replace the current prompt with this template?', 'tainacan-ai'),
                 'confirmClearCache' => __('Are you sure you want to clear all cache?', 'tainacan-ai'),
                 'selectCollectionFirst' => __('Select a collection first.', 'tainacan-ai'),
                 'loadingMetadata' => __('Loading metadata...', 'tainacan-ai'),
@@ -145,7 +147,7 @@ class AdminPage extends \Tainacan\Pages {
         $options = get_option('tainacan_ai_options', []);
 
         // Long text fields (prompts)
-        $textarea_fields = ['default_image_prompt', 'default_document_prompt'];
+        $textarea_fields = ['default_prompt'];
         foreach ($textarea_fields as $field) {
             if (isset($input[$field])) {
                 $options[$field] = wp_kses_post($input[$field]);

--- a/includes/CollectionFormHook.php
+++ b/includes/CollectionFormHook.php
@@ -37,10 +37,7 @@ class CollectionFormHook {
      * @return array<string>
      */
     public function add_meta_to_response(array $extra_meta, $request): array {
-        foreach (CollectionPrompts::PROMPT_TYPES as $type) {
-            $extra_meta[] = CollectionPrompts::meta_key_text($type);
-            $extra_meta[] = CollectionPrompts::meta_key_mapping($type);
-        }
+        $extra_meta[] = CollectionPrompts::meta_key_text();
 
         return $extra_meta;
     }
@@ -60,25 +57,20 @@ class CollectionFormHook {
         }
 
         $collection_id = (int) $collection->get_id();
+        $text_key = CollectionPrompts::meta_key_text();
 
-        foreach (CollectionPrompts::PROMPT_TYPES as $type) {
-            $text_key = CollectionPrompts::meta_key_text($type);
-            $mapping_key = CollectionPrompts::meta_key_mapping($type);
-
-            if (!isset($post->{$text_key})) {
-                continue;
-            }
-
-            $prompt_text = wp_kses_post((string) $post->{$text_key});
-
-            if ($prompt_text === '') {
-                delete_post_meta($collection_id, $text_key);
-                delete_post_meta($collection_id, $mapping_key);
-                continue;
-            }
-
-            update_post_meta($collection_id, $text_key, $prompt_text);
+        if (!isset($post->{$text_key})) {
+            return;
         }
+
+        $prompt_text = wp_kses_post((string) $post->{$text_key});
+
+        if ($prompt_text === '') {
+            delete_post_meta($collection_id, $text_key);
+            return;
+        }
+
+        update_post_meta($collection_id, $text_key, $prompt_text);
     }
 
     public function render_form(): string {
@@ -91,7 +83,7 @@ class CollectionFormHook {
         ob_start();
         ?>
         <div class="field tainacan-collection--section-header">
-            <h4><?php esc_html_e('Tainacan AI prompts', 'tainacan-ai'); ?></h4>
+            <h4><?php esc_html_e('Tainacan AI prompt', 'tainacan-ai'); ?></h4>
             <hr>
         </div>
 
@@ -100,35 +92,26 @@ class CollectionFormHook {
             echo wp_kses_post(
                 sprintf(
                     /* translators: %s: link to Tainacan AI settings page */
-                    __('Override site-wide defaults for this collection. Leave blank to use <a href="%s">Tainacan AI settings</a>. Field mapping is edited there.', 'tainacan-ai'),
+                    __('Override the site-wide prompt for this collection. Leave blank to use <a href="%s">Tainacan AI settings</a>. Field mapping is edited there.', 'tainacan-ai'),
                     esc_url($ai_tools_url)
                 )
             );
             ?>
         </p>
-
-        <?php foreach (CollectionPrompts::PROMPT_TYPES as $type) : ?>
-            <?php
-            $label = $type === 'image'
-                ? __('Image analysis prompt', 'tainacan-ai')
-                : __('Document analysis prompt', 'tainacan-ai');
-            $meta_key = CollectionPrompts::meta_key_text($type);
-            ?>
-            <div class="field">
-                <label class="label" for="<?php echo esc_attr($meta_key); ?>">
-                    <?php echo esc_html($label); ?>
-                </label>
-                <div class="control">
-                    <textarea
-                        id="<?php echo esc_attr($meta_key); ?>"
-                        class="textarea"
-                        name="<?php echo esc_attr($meta_key); ?>"
-                        rows="6"
-                        placeholder="<?php echo esc_attr__('Leave empty to use the default prompt…', 'tainacan-ai'); ?>"
-                    ></textarea>
-                </div>
+        <div class="field">
+            <label class="label" for="<?php echo esc_attr(CollectionPrompts::meta_key_text()); ?>">
+                <?php esc_html_e('Analysis prompt', 'tainacan-ai'); ?>
+            </label>
+            <div class="control">
+                <textarea
+                    id="<?php echo esc_attr(CollectionPrompts::meta_key_text()); ?>"
+                    class="textarea"
+                    name="<?php echo esc_attr(CollectionPrompts::meta_key_text()); ?>"
+                    rows="6"
+                    placeholder="<?php echo esc_attr__('Leave empty to use the default prompt…', 'tainacan-ai'); ?>"
+                ></textarea>
             </div>
-        <?php endforeach; ?>
+        </div>
         <?php
 
         return (string) ob_get_clean();

--- a/includes/CollectionPrompts.php
+++ b/includes/CollectionPrompts.php
@@ -11,9 +11,7 @@ if (!defined('ABSPATH')) {
 class CollectionPrompts {
 
     public const POST_TYPE = 'tainacan-collection';
-
-    /** @var list<string> */
-    public const PROMPT_TYPES = ['image', 'document'];
+    public const META_KEY_TEXT = 'tainacan_ai_prompt_text';
 
     public function __construct() {
         $this->init_hooks();
@@ -32,82 +30,52 @@ class CollectionPrompts {
             return current_user_can('edit_posts');
         };
 
-        foreach (self::PROMPT_TYPES as $type) {
-            register_post_meta(
-                self::POST_TYPE,
-                self::meta_key_text($type),
-                [
-                    'type' => 'string',
-                    'single' => true,
-                    'show_in_rest' => true,
-                    'auth_callback' => $auth_callback,
-                ]
-            );
-
-            register_post_meta(
-                self::POST_TYPE,
-                self::meta_key_mapping($type),
-                [
-                    'type' => 'array',
-                    'single' => true,
-                    'show_in_rest' => [
-                        'schema' => [
-                            'type' => 'object',
-                            'additionalProperties' => true,
-                        ],
-                    ],
-                    'auth_callback' => $auth_callback,
-                ]
-            );
-        }
+        register_post_meta(
+            self::POST_TYPE,
+            self::META_KEY_TEXT,
+            [
+                'type' => 'string',
+                'single' => true,
+                'show_in_rest' => true,
+                'auth_callback' => $auth_callback,
+            ]
+        );
     }
 
-    public static function meta_key_text(string $type): string {
-        return 'tainacan_ai_prompt_' . self::sanitize_prompt_type($type) . '_text';
-    }
-
-    public static function meta_key_mapping(string $type): string {
-        return 'tainacan_ai_prompt_' . self::sanitize_prompt_type($type) . '_metadata_mapping';
+    public static function meta_key_text(): string {
+        return self::META_KEY_TEXT;
     }
 
     /**
      * @return array<string, mixed>|null
      */
-    public function get_prompt(int $collection_id, string $type = 'image'): ?array {
+    public function get_prompt(int $collection_id): ?array {
         if (!$this->is_collection($collection_id)) {
             return null;
         }
 
-        $type = self::sanitize_prompt_type($type);
-        $prompt_text = (string) get_post_meta($collection_id, self::meta_key_text($type), true);
+        $prompt_text = (string) get_post_meta($collection_id, self::meta_key_text(), true);
 
         if ($prompt_text === '') {
             return null;
         }
 
-        $metadata_mapping = get_post_meta($collection_id, self::meta_key_mapping($type), true);
-
         return [
             'collection_id' => $collection_id,
-            'prompt_type' => $type,
             'prompt_text' => $prompt_text,
-            'metadata_mapping' => is_array($metadata_mapping) ? $metadata_mapping : [],
             'is_active' => 1,
         ];
     }
 
-    public function get_effective_prompt(int $collection_id, string $type = 'image'): string {
-        $custom_prompt = $this->get_prompt($collection_id, $type);
+    public function get_effective_prompt(int $collection_id): string {
+        $custom_prompt = $this->get_prompt($collection_id);
 
         if ($custom_prompt && !empty($custom_prompt['prompt_text'])) {
             return $custom_prompt['prompt_text'];
         }
 
         $options = \Tainacan_AI::get_options();
-
-        return $type === 'image'
-            ? ($options['default_image_prompt'] ?? '')
-            : ($options['default_document_prompt'] ?? '');
+        return (string) ($options['default_prompt'] ?? '');
     }
 
     public function get_collection_metadata(int $collection_id): array {
@@ -161,9 +129,5 @@ class CollectionPrompts {
 
     private function is_collection(int $collection_id): bool {
         return $collection_id > 0 && get_post_type($collection_id) === self::POST_TYPE;
-    }
-
-    private static function sanitize_prompt_type(string $type): string {
-        return in_array($type, self::PROMPT_TYPES, true) ? $type : 'image';
     }
 }

--- a/includes/DocumentAnalyzer.php
+++ b/includes/DocumentAnalyzer.php
@@ -368,10 +368,10 @@ class DocumentAnalyzer {
             }
 
             // Get prompt
-            $prompt = $this->get_prompt('document');
+            $prompt = $this->get_prompt();
 
             if (empty($prompt)) {
-                return new \WP_Error('no_prompt', __('No prompt configured for document analysis.', 'tainacan-ai'));
+                return new \WP_Error('no_prompt', __('No analysis prompt configured.', 'tainacan-ai'));
             }
 
             $pageCount = count($images);
@@ -450,10 +450,10 @@ class DocumentAnalyzer {
         }
 
         // Get prompt
-        $prompt = $this->get_prompt('image');
+        $prompt = $this->get_prompt();
 
         if (empty($prompt)) {
-            return new \WP_Error('no_prompt', __('No prompt configured for image analysis.', 'tainacan-ai'));
+            return new \WP_Error('no_prompt', __('No analysis prompt configured.', 'tainacan-ai'));
         }
 
         return CoreAI::generate_json_from_text_and_files(
@@ -488,10 +488,10 @@ class DocumentAnalyzer {
         }
 
         // Get prompt
-        $prompt = $this->get_prompt('document');
+        $prompt = $this->get_prompt();
 
         if (empty($prompt)) {
-            return new \WP_Error('no_prompt', __('No prompt configured for document analysis.', 'tainacan-ai'));
+            return new \WP_Error('no_prompt', __('No analysis prompt configured.', 'tainacan-ai'));
         }
 
         $full_prompt = $prompt . "\n\n---\n\n**Documento:**\n\n" . $text;
@@ -506,27 +506,26 @@ class DocumentAnalyzer {
      * and generates a dynamic prompt based on those fields so AI
      * returns exactly the mapped fields.
      */
-    private function get_prompt(string $type): string {
+    private function get_prompt(): string {
         // First, check if there's custom mapping saved in admin
         if ($this->collection_id) {
             $custom_mapping = get_option('tainacan_ai_mapping_' . $this->collection_id, []);
 
             if (!empty($custom_mapping)) {
-                $prompt = $this->generate_prompt_from_mapping($custom_mapping, $type);
+                $prompt = $this->generate_prompt_from_mapping($custom_mapping);
                 if (!empty($prompt)) {
                     return $prompt;
                 }
             }
 
             // If no custom mapping, try collection prompt
-            $prompt = $this->collection_prompts->get_effective_prompt($this->collection_id, $type);
+            $prompt = $this->collection_prompts->get_effective_prompt($this->collection_id);
             if (!empty($prompt)) {
                 return $prompt;
             }
         }
 
-        $key = $type === 'image' ? 'default_image_prompt' : 'default_document_prompt';
-        return $this->options[$key] ?? '';
+        return (string) ($this->options['default_prompt'] ?? '');
     }
 
     /**
@@ -535,7 +534,7 @@ class DocumentAnalyzer {
      * Creates a prompt that instructs AI to return JSON with exactly
      * the fields defined in the mapping, using the correct keys.
      */
-    private function generate_prompt_from_mapping(array $mapping, string $type): string {
+    private function generate_prompt_from_mapping(array $mapping): string {
         if (empty($mapping)) {
             return '';
         }
@@ -559,35 +558,19 @@ class DocumentAnalyzer {
         $fields_text = implode("\n", $fields_list);
         $json_text = json_encode($json_example, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
 
-        if ($type === 'image') {
-            return 'Você é um especialista em análise e catalogação de imagens de acervos culturais. Analise esta imagem cuidadosamente e extraia informações para os campos especificados abaixo.' . "\n\n" .
+        return 'Você é um especialista em catalogação de acervos. Analise o conteúdo fornecido e extraia informações para os campos especificados abaixo.' . "\n\n" .
 '## Campos para Extrair:' . "\n" .
 $fields_text . "\n\n" .
 '## Instruções:' . "\n" .
-'1. Analise a imagem detalhadamente' . "\n" .
+'1. Analise o conteúdo com atenção' . "\n" .
 '2. Extraia informações relevantes para CADA campo listado' . "\n" .
-'3. Se não conseguir identificar um campo, use null' . "\n" .
+'3. Se não encontrar informação para um campo, use null' . "\n" .
 '4. Para campos com múltiplos valores, use array' . "\n" .
 '5. Seja preciso e objetivo' . "\n\n" .
 '## Formato de Resposta:' . "\n" .
 'Retorne APENAS um JSON válido com esta estrutura (use EXATAMENTE estas chaves):' . "\n" .
 $json_text . "\n\n" .
 'IMPORTANTE: Use EXATAMENTE as chaves mostradas acima (como "titulo", "autor", etc.). Responda SOMENTE com o JSON, sem texto adicional.';
-        } else {
-            return 'Você é um especialista em análise documental e catalogação. Analise este documento e extraia informações para os campos especificados abaixo.' . "\n\n" .
-'## Campos para Extrair:' . "\n" .
-$fields_text . "\n\n" .
-'## Instruções:' . "\n" .
-'1. Leia o documento completamente' . "\n" .
-'2. Extraia informações para CADA campo listado' . "\n" .
-'3. Se não encontrar informação para um campo, use null' . "\n" .
-'4. Para campos com múltiplos valores, use array' . "\n" .
-'5. Seja preciso nas citações' . "\n\n" .
-'## Formato de Resposta:' . "\n" .
-'Retorne APENAS um JSON válido com esta estrutura (use EXATAMENTE estas chaves):' . "\n" .
-$json_text . "\n\n" .
-'IMPORTANTE: Use EXATAMENTE as chaves mostradas acima (como "titulo", "autor", etc.). Responda SOMENTE com o JSON, sem texto adicional.';
-        }
     }
 
     /**

--- a/includes/PromptTemplates.php
+++ b/includes/PromptTemplates.php
@@ -1,0 +1,151 @@
+<?php
+namespace Tainacan\AI;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class PromptTemplates {
+
+    public static function get_default_prompt(): string {
+        return self::get_image_template();
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    public static function get_templates(): array {
+        return [
+            'image' => [
+                'label' => __('Image analysis', 'tainacan-ai'),
+                'description' => __('Default template for visual and museological analysis of image files.', 'tainacan-ai'),
+                'content' => self::get_image_template(),
+            ],
+            'document' => [
+                'label' => __('Document analysis', 'tainacan-ai'),
+                'description' => __('Suggested template for bibliographic and textual documents.', 'tainacan-ai'),
+                'content' => self::get_document_template(),
+            ],
+        ];
+    }
+
+    private static function get_image_template(): string {
+        return 'Você é um especialista em catalogação museológica e arquivística. Analise esta imagem e extraia metadados detalhados.' . "\n\n" .
+'## Instruções:' . "\n" .
+'1. Analise cuidadosamente todos os elementos visuais' . "\n" .
+'2. Identifique técnicas artísticas, materiais e estilos' . "\n" .
+'3. Estime períodos históricos quando possível' . "\n" .
+'4. Descreva o estado de conservação visível' . "\n" .
+'5. Para CADA campo, inclua a evidência de onde a informação foi extraída' . "\n\n" .
+'## Retorne um JSON com os seguintes campos (cada campo deve ter "valor" e "evidencia"):' . "\n" .
+'{' . "\n" .
+'    "titulo": {' . "\n" .
+'        "valor": "Título descritivo da obra/objeto",' . "\n" .
+'        "evidencia": "Descrição de qual elemento visual ou texto levou a esta conclusão"' . "\n" .
+'    },' . "\n" .
+'    "autor": {' . "\n" .
+'        "valor": "Nome do autor/criador (ou \'Desconhecido\')",' . "\n" .
+'        "evidencia": "Assinatura visível, estilo característico, ou \'Não identificado na imagem\'"' . "\n" .
+'    },' . "\n" .
+'    "data_criacao": {' . "\n" .
+'        "valor": "Data ou período estimado",' . "\n" .
+'        "evidencia": "Elementos que indicam a época (estilo, materiais, técnica, inscrições)"' . "\n" .
+'    },' . "\n" .
+'    "tecnica": {' . "\n" .
+'        "valor": "Técnica(s) utilizada(s)",' . "\n" .
+'        "evidencia": "Características visuais que identificam a técnica"' . "\n" .
+'    },' . "\n" .
+'    "materiais": {' . "\n" .
+'        "valor": ["lista", "de", "materiais"],' . "\n" .
+'        "evidencia": "Texturas, cores e características que indicam os materiais"' . "\n" .
+'    },' . "\n" .
+'    "dimensoes_estimadas": {' . "\n" .
+'        "valor": "Dimensões aproximadas",' . "\n" .
+'        "evidencia": "Elementos de referência usados para estimar (objetos conhecidos, proporções)"' . "\n" .
+'    },' . "\n" .
+'    "estado_conservacao": {' . "\n" .
+'        "valor": "Bom/Regular/Ruim - descrição",' . "\n" .
+'        "evidencia": "Sinais visíveis de desgaste, danos ou boa preservação"' . "\n" .
+'    },' . "\n" .
+'    "descricao": {' . "\n" .
+'        "valor": "Descrição visual detalhada",' . "\n" .
+'        "evidencia": "Elementos principais observados na imagem"' . "\n" .
+'    },' . "\n" .
+'    "estilo_artistico": {' . "\n" .
+'        "valor": "Estilo ou movimento artístico",' . "\n" .
+'        "evidencia": "Características formais que indicam o estilo"' . "\n" .
+'    },' . "\n" .
+'    "palavras_chave": {' . "\n" .
+'        "valor": ["palavras", "chave", "relevantes"],' . "\n" .
+'        "evidencia": "Temas e elementos principais identificados"' . "\n" .
+'    },' . "\n" .
+'    "observacoes": {' . "\n" .
+'        "valor": "Outras observações relevantes",' . "\n" .
+'        "evidencia": "Detalhes adicionais notados"' . "\n" .
+'    }' . "\n" .
+'}' . "\n\n" .
+'Responda APENAS com o JSON, sem texto adicional.';
+    }
+
+    private static function get_document_template(): string {
+        return 'Você é um especialista em análise documental e bibliográfica. Analise este documento e extraia metadados estruturados.' . "\n\n" .
+'## Instruções:' . "\n" .
+'1. Identifique o tipo de documento (artigo, relatório, tese, etc.)' . "\n" .
+'2. Extraia informações bibliográficas completas' . "\n" .
+'3. Identifique temas e áreas de conhecimento' . "\n" .
+'4. Resuma o conteúdo principal' . "\n" .
+'5. Para CADA campo, inclua a evidência de onde a informação foi extraída (página, seção, trecho do texto)' . "\n\n" .
+'## Retorne um JSON com os seguintes campos (cada campo deve ter "valor" e "evidencia"):' . "\n" .
+'{' . "\n" .
+'    "titulo": {' . "\n" .
+'        "valor": "Título do documento",' . "\n" .
+'        "evidencia": "Local onde o título foi encontrado (capa, cabeçalho, página X)"' . "\n" .
+'    },' . "\n" .
+'    "autor": {' . "\n" .
+'        "valor": ["Nome dos autores"],' . "\n" .
+'        "evidencia": "Local onde os autores foram identificados (capa, página X, seção de autoria)"' . "\n" .
+'    },' . "\n" .
+'    "tipo_documento": {' . "\n" .
+'        "valor": "Artigo/Relatório/Tese/Livro/etc",' . "\n" .
+'        "evidencia": "Elementos que indicam o tipo (estrutura, formatação, declarações explícitas)"' . "\n" .
+'    },' . "\n" .
+'    "ano_publicacao": {' . "\n" .
+'        "valor": "Ano",' . "\n" .
+'        "evidencia": "Local onde a data foi encontrada"' . "\n" .
+'    },' . "\n" .
+'    "instituicao": {' . "\n" .
+'        "valor": "Instituição relacionada",' . "\n" .
+'        "evidencia": "Menções à instituição no documento"' . "\n" .
+'    },' . "\n" .
+'    "resumo": {' . "\n" .
+'        "valor": "Resumo do conteúdo (máx. 500 caracteres)",' . "\n" .
+'        "evidencia": "Seções principais que fundamentam o resumo"' . "\n" .
+'    },' . "\n" .
+'    "palavras_chave": {' . "\n" .
+'        "valor": ["palavras", "chave"],' . "\n" .
+'        "evidencia": "Seção de palavras-chave ou temas recorrentes identificados"' . "\n" .
+'    },' . "\n" .
+'    "area_conhecimento": {' . "\n" .
+'        "valor": "Área principal",' . "\n" .
+'        "evidencia": "Indicadores da área (terminologia, metodologia, referências)"' . "\n" .
+'    },' . "\n" .
+'    "idioma": {' . "\n" .
+'        "valor": "Idioma do documento",' . "\n" .
+'        "evidencia": "Idioma identificado no texto"' . "\n" .
+'    },' . "\n" .
+'    "referencias_principais": {' . "\n" .
+'        "valor": ["Referências importantes citadas"],' . "\n" .
+'        "evidencia": "Seção de referências ou citações no texto"' . "\n" .
+'    },' . "\n" .
+'    "metodologia": {' . "\n" .
+'        "valor": "Metodologia utilizada (se aplicável)",' . "\n" .
+'        "evidencia": "Seção de metodologia ou descrição dos métodos"' . "\n" .
+'    },' . "\n" .
+'    "observacoes": {' . "\n" .
+'        "valor": "Outras observações",' . "\n" .
+'        "evidencia": "Elementos adicionais notados no documento"' . "\n" .
+'    }' . "\n" .
+'}' . "\n\n" .
+'Responda APENAS com o JSON, sem texto adicional.';
+    }
+}

--- a/includes/PromptTemplates.php
+++ b/includes/PromptTemplates.php
@@ -8,14 +8,21 @@ if (!defined('ABSPATH')) {
 class PromptTemplates {
 
     public static function get_default_prompt(): string {
-        return self::get_image_template();
+        $default_prompt = self::get_image_template();
+
+        /**
+         * Filters the default analysis prompt used by Tainacan AI.
+         *
+         * @param string $default_prompt The default prompt text.
+         */
+        return (string) apply_filters('tainacan_ai_default_prompt', $default_prompt);
     }
 
     /**
      * @return array<string, array<string, string>>
      */
     public static function get_templates(): array {
-        return [
+        $templates = [
             'image' => [
                 'label' => __('Image analysis', 'tainacan-ai'),
                 'description' => __('Default template for visual and museological analysis of image files.', 'tainacan-ai'),
@@ -27,6 +34,36 @@ class PromptTemplates {
                 'content' => self::get_document_template(),
             ],
         ];
+
+        /**
+         * Filters prompt template suggestions shown in the admin.
+         *
+         * @param array<string, array<string, string>> $templates Template map keyed by template slug.
+         */
+        $templates = apply_filters('tainacan_ai_prompt_templates', $templates);
+        if (!is_array($templates)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($templates as $key => $template) {
+            if (!is_string($key) || !is_array($template)) {
+                continue;
+            }
+
+            $content = isset($template['content']) ? (string) $template['content'] : '';
+            if ($content === '') {
+                continue;
+            }
+
+            $normalized[$key] = [
+                'label' => isset($template['label']) ? (string) $template['label'] : $key,
+                'description' => isset($template['description']) ? (string) $template['description'] : '',
+                'content' => $content,
+            ];
+        }
+
+        return $normalized;
     }
 
     private static function get_image_template(): string {

--- a/includes/admin/admin-page.php
+++ b/includes/admin/admin-page.php
@@ -70,6 +70,7 @@ if (function_exists('shell_exec')) {
 }
 
 $tainacan_ai_has_visual = $tainacan_ai_has_imagick_pdf || $tainacan_ai_has_ghostscript;
+$tainacan_ai_prompt_templates = \Tainacan\AI\PromptTemplates::get_templates();
 ?>
 
 <div class="wrap tainacan-page-container-content tainacan-ai-admin">
@@ -92,12 +93,12 @@ $tainacan_ai_has_visual = $tainacan_ai_has_imagick_pdf || $tainacan_ai_has_ghost
 
             <div class="tainacan-ai-form-fields">
 
-                <!-- Seção: Prompts Padrão -->
+                <!-- Seção: Prompt padrão -->
                 <div class="tainacan-ai-card">
                     <div class="tainacan-ai-card-header">
                         <div class="tainacan-ai-card-title">
                             <span class="dashicons dashicons-edit-page"></span>
-                            <h2><?php esc_html_e('Default Analysis Prompts', 'tainacan-ai'); ?></h2>
+                            <h2><?php esc_html_e('Default analysis prompt', 'tainacan-ai'); ?></h2>
                         </div>
                         <button type="button" class="tainacan-ai-toggle-card">
                             <span class="dashicons dashicons-arrow-down-alt2"></span>
@@ -105,32 +106,42 @@ $tainacan_ai_has_visual = $tainacan_ai_has_imagick_pdf || $tainacan_ai_has_ghost
                     </div>
                     <div class="tainacan-ai-card-body tainacan-ai-collapsible">
                         <p class="tainacan-ai-card-description">
-                            <?php esc_html_e('Prompts define how the AI should analyze documents. Use clear instructions and specify the JSON fields you want to extract.', 'tainacan-ai'); ?>
+                            <?php esc_html_e('This prompt is used as the default for every file type. Use collection-level overrides when needed.', 'tainacan-ai'); ?>
                         </p>
 
                         <div class="tainacan-ai-field">
-                            <label for="default_image_prompt">
-                                <?php esc_html_e('Prompt for Images', 'tainacan-ai'); ?>
+                            <label for="default_prompt">
+                                <?php esc_html_e('Default prompt', 'tainacan-ai'); ?>
                             </label>
                             <textarea
-                                id="default_image_prompt"
-                                name="tainacan_ai_options[default_image_prompt]"
-                                rows="8"
+                                id="default_prompt"
+                                name="tainacan_ai_options[default_prompt]"
+                                rows="10"
                                 class="large-text code"
-                            ><?php echo esc_textarea($options['default_image_prompt'] ?? ''); ?></textarea>
+                            ><?php echo esc_textarea($options['default_prompt'] ?? ''); ?></textarea>
                         </div>
 
-                        <div class="tainacan-ai-field">
-                            <label for="default_document_prompt">
-                                <?php esc_html_e('Prompt for Documents', 'tainacan-ai'); ?>
-                            </label>
-                            <textarea
-                                id="default_document_prompt"
-                                name="tainacan_ai_options[default_document_prompt]"
-                                rows="8"
-                                class="large-text code"
-                            ><?php echo esc_textarea($options['default_document_prompt'] ?? ''); ?></textarea>
-                        </div>
+                        <details class="tainacan-ai-prompt-templates">
+                            <summary><?php esc_html_e('Suggested prompts', 'tainacan-ai'); ?></summary>
+                            <?php foreach ($tainacan_ai_prompt_templates as $template_key => $template) : ?>
+                                <article class="tainacan-ai-prompt-template">
+                                    <header class="tainacan-ai-prompt-template-header">
+                                        <h3><?php echo esc_html($template['label']); ?></h3>
+                                        <button
+                                            type="button"
+                                            class="button button-small tainacan-ai-use-prompt-template"
+                                            data-template-key="<?php echo esc_attr($template_key); ?>"
+                                        >
+                                            <?php esc_html_e('Use this template', 'tainacan-ai'); ?>
+                                        </button>
+                                    </header>
+                                    <?php if (!empty($template['description'])) : ?>
+                                        <p class="description"><?php echo esc_html($template['description']); ?></p>
+                                    <?php endif; ?>
+                                    <textarea readonly rows="10" class="large-text code"><?php echo esc_textarea($template['content']); ?></textarea>
+                                </article>
+                            <?php endforeach; ?>
+                        </details>
                     </div>
                 </div>
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Tainacan AI extends the [Tainacan](https://wordpress.org/plugins/tainacan/) plug
 * **WordPress AI & Connectors**: Uses the site’s configured AI connectors
 * **Image analysis**: Extract structured metadata from images when your connector supports it
 * **Document analysis**: Extract bibliographic-style or custom JSON fields from PDFs, TXT, and HTML
-* **Custom prompts per collection**: Specialized prompts for different collections and schemas
+* **Custom prompts per collection**: A single prompt per collection to guide extraction for any supported file type
 * **Metadata mapping**: Map AI output keys to Tainacan metadata for fill workflows
 * **EXIF data extraction**: Optional technical metadata from image files (when the server supports it)
 * **PDF support**: Text extraction via bundled parser; optional visual analysis depends on Imagick/Ghostscript and the connector
@@ -52,7 +52,7 @@ Connectors and credentials are managed in **Settings → Connectors**. The plugi
 
 = Customization =
 
-Configure default prompts, per-collection overrides on the collection edition form, field mapping, features such as EXIF extraction, and clear cache from **Tainacan → Others → AI Tools**.
+Configure a default analysis prompt, per-collection overrides on the collection edition form, suggested prompt templates, field mapping, features such as EXIF extraction, and clear cache from **Tainacan → Others → AI Tools**.
 
 == Installation ==
 
@@ -120,7 +120,7 @@ You can configure multiple connectors in WordPress; this plugin does not maintai
 == Screenshots ==
 
 1. AI Tools settings page (prompts, features, cache)
-2. Custom prompt configuration for collections
+2. Collection edit form with per-collection prompt override
 3. Metadata mapping interface
 4. Document analysis in the item edit form
 

--- a/src/css/admin.css
+++ b/src/css/admin.css
@@ -498,6 +498,46 @@
 }
 
 /* ================================
+   Prompt templates
+   ================================ */
+.tainacan-ai-prompt-templates {
+    margin-top: 16px;
+    border: 1px solid var(--tainacan-ai-border);
+    border-radius: var(--tainacan-input-border-radius, 8px);
+    background: var(--tainacan-ai-white);
+    padding: 12px;
+}
+
+.tainacan-ai-prompt-templates > summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--tainacan-ai-primary);
+}
+
+.tainacan-ai-prompt-template {
+    margin-top: 14px;
+    border-top: 1px solid var(--tainacan-ai-border);
+    padding-top: 14px;
+}
+
+.tainacan-ai-prompt-template-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 6px;
+}
+
+.tainacan-ai-prompt-template-header h3 {
+    margin: 0;
+    font-size: 14px;
+}
+
+.tainacan-ai-prompt-template textarea[readonly] {
+    background: var(--tainacan-ai-bg-light);
+}
+
+/* ================================
    Actions Bar
    ================================ */
 .tainacan-ai-actions-bar {

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -23,6 +23,10 @@
 
 			// Toggle cards
 			$( '.tainacan-ai-toggle-card' ).on( 'click', this.toggleCard );
+			$( '.tainacan-ai-use-prompt-template' ).on(
+				'click',
+				this.applyPromptTemplate.bind( this )
+			);
 
 			// Field Mapping
 			$( '#mapping-collection-select' ).on(
@@ -113,6 +117,33 @@
 					.hasClass( 'collapsed' );
 				$card.toggleClass( 'is-collapsed', isCollapsed );
 			} );
+		},
+
+		applyPromptTemplate( e ) {
+			const templateKey = $( e.currentTarget ).data( 'template-key' );
+			const template =
+				TainacanAIAdmin.promptTemplates?.[ templateKey ] || null;
+			const $textarea = $( '#default_prompt' );
+
+			if ( ! template || ! template.content || ! $textarea.length ) {
+				Admin.showNotice( TainacanAIAdmin.texts.error, 'error' );
+				return;
+			}
+
+			const currentValue = ( $textarea.val() || '' ).toString().trim();
+			const nextValue = template.content.toString();
+			if (
+				currentValue &&
+				currentValue !== nextValue.trim() &&
+				! confirm(
+					TainacanAIAdmin.texts.confirmReplacePromptTemplate ||
+						'Replace the current prompt with this template?'
+				)
+			) {
+				return;
+			}
+
+			$textarea.val( nextValue ).trigger( 'change' ).focus();
 		},
 
 		populateMappingCollections() {

--- a/tainacan-ai.php
+++ b/tainacan-ai.php
@@ -113,7 +113,6 @@ final class Tainacan_AI {
         }
 
         $this->set_default_options();
-        $this->prune_legacy_option_keys();
 
         // Flush rewrite rules
         flush_rewrite_rules();
@@ -137,8 +136,7 @@ final class Tainacan_AI {
      */
     private function set_default_options(): void {
         $default_options = [
-            'default_image_prompt' => $this->get_default_image_prompt(),
-            'default_document_prompt' => $this->get_default_document_prompt(),
+            'default_prompt' => \Tainacan\AI\PromptTemplates::get_default_prompt(),
             'max_tokens' => 2000,
             'temperature' => 0.1,
             'request_timeout' => 120,
@@ -150,164 +148,6 @@ final class Tainacan_AI {
 
         $existing = get_option('tainacan_ai_options', []);
         update_option('tainacan_ai_options', wp_parse_args($existing, $default_options));
-    }
-
-    /**
-     * Remove legacy in-plugin provider option keys (pre–WordPress Connectors).
-     */
-    private function prune_legacy_option_keys(): void {
-        $legacy_keys = [
-            'api_key',
-            'gemini_api_key',
-            'deepseek_api_key',
-            'ollama_url',
-            'default_provider',
-            'provider',
-            'model',
-        ];
-
-        $options = get_option('tainacan_ai_options', []);
-        if (!is_array($options)) {
-            return;
-        }
-
-        $changed = false;
-        foreach ($legacy_keys as $key) {
-            if (array_key_exists($key, $options)) {
-                unset($options[$key]);
-                $changed = true;
-            }
-        }
-
-        if ($changed) {
-            update_option('tainacan_ai_options', $options);
-        }
-    }
-
-    /**
-     * Default prompt for images
-     */
-    private function get_default_image_prompt(): string {
-        return 'Você é um especialista em catalogação museológica e arquivística. Analise esta imagem e extraia metadados detalhados.' . "\n\n" .
-'## Instruções:' . "\n" .
-'1. Analise cuidadosamente todos os elementos visuais' . "\n" .
-'2. Identifique técnicas artísticas, materiais e estilos' . "\n" .
-'3. Estime períodos históricos quando possível' . "\n" .
-'4. Descreva o estado de conservação visível' . "\n" .
-'5. Para CADA campo, inclua a evidência de onde a informação foi extraída' . "\n\n" .
-'## Retorne um JSON com os seguintes campos (cada campo deve ter "valor" e "evidencia"):' . "\n" .
-'{' . "\n" .
-'    "titulo": {' . "\n" .
-'        "valor": "Título descritivo da obra/objeto",' . "\n" .
-'        "evidencia": "Descrição de qual elemento visual ou texto levou a esta conclusão"' . "\n" .
-'    },' . "\n" .
-'    "autor": {' . "\n" .
-'        "valor": "Nome do autor/criador (ou \'Desconhecido\')",' . "\n" .
-'        "evidencia": "Assinatura visível, estilo característico, ou \'Não identificado na imagem\'"' . "\n" .
-'    },' . "\n" .
-'    "data_criacao": {' . "\n" .
-'        "valor": "Data ou período estimado",' . "\n" .
-'        "evidencia": "Elementos que indicam a época (estilo, materiais, técnica, inscrições)"' . "\n" .
-'    },' . "\n" .
-'    "tecnica": {' . "\n" .
-'        "valor": "Técnica(s) utilizada(s)",' . "\n" .
-'        "evidencia": "Características visuais que identificam a técnica"' . "\n" .
-'    },' . "\n" .
-'    "materiais": {' . "\n" .
-'        "valor": ["lista", "de", "materiais"],' . "\n" .
-'        "evidencia": "Texturas, cores e características que indicam os materiais"' . "\n" .
-'    },' . "\n" .
-'    "dimensoes_estimadas": {' . "\n" .
-'        "valor": "Dimensões aproximadas",' . "\n" .
-'        "evidencia": "Elementos de referência usados para estimar (objetos conhecidos, proporções)"' . "\n" .
-'    },' . "\n" .
-'    "estado_conservacao": {' . "\n" .
-'        "valor": "Bom/Regular/Ruim - descrição",' . "\n" .
-'        "evidencia": "Sinais visíveis de desgaste, danos ou boa preservação"' . "\n" .
-'    },' . "\n" .
-'    "descricao": {' . "\n" .
-'        "valor": "Descrição visual detalhada",' . "\n" .
-'        "evidencia": "Elementos principais observados na imagem"' . "\n" .
-'    },' . "\n" .
-'    "estilo_artistico": {' . "\n" .
-'        "valor": "Estilo ou movimento artístico",' . "\n" .
-'        "evidencia": "Características formais que indicam o estilo"' . "\n" .
-'    },' . "\n" .
-'    "palavras_chave": {' . "\n" .
-'        "valor": ["palavras", "chave", "relevantes"],' . "\n" .
-'        "evidencia": "Temas e elementos principais identificados"' . "\n" .
-'    },' . "\n" .
-'    "observacoes": {' . "\n" .
-'        "valor": "Outras observações relevantes",' . "\n" .
-'        "evidencia": "Detalhes adicionais notados"' . "\n" .
-'    }' . "\n" .
-'}' . "\n\n" .
-'Responda APENAS com o JSON, sem texto adicional.';
-    }
-
-    /**
-     * Default prompt for documents
-     */
-    private function get_default_document_prompt(): string {
-        return 'Você é um especialista em análise documental e bibliográfica. Analise este documento e extraia metadados estruturados.' . "\n\n" .
-'## Instruções:' . "\n" .
-'1. Identifique o tipo de documento (artigo, relatório, tese, etc.)' . "\n" .
-'2. Extraia informações bibliográficas completas' . "\n" .
-'3. Identifique temas e áreas de conhecimento' . "\n" .
-'4. Resuma o conteúdo principal' . "\n" .
-'5. Para CADA campo, inclua a evidência de onde a informação foi extraída (página, seção, trecho do texto)' . "\n\n" .
-'## Retorne um JSON com os seguintes campos (cada campo deve ter "valor" e "evidencia"):' . "\n" .
-'{' . "\n" .
-'    "titulo": {' . "\n" .
-'        "valor": "Título do documento",' . "\n" .
-'        "evidencia": "Local onde o título foi encontrado (capa, cabeçalho, página X)"' . "\n" .
-'    },' . "\n" .
-'    "autor": {' . "\n" .
-'        "valor": ["Nome dos autores"],' . "\n" .
-'        "evidencia": "Local onde os autores foram identificados (capa, página X, seção de autoria)"' . "\n" .
-'    },' . "\n" .
-'    "tipo_documento": {' . "\n" .
-'        "valor": "Artigo/Relatório/Tese/Livro/etc",' . "\n" .
-'        "evidencia": "Elementos que indicam o tipo (estrutura, formatação, declarações explícitas)"' . "\n" .
-'    },' . "\n" .
-'    "ano_publicacao": {' . "\n" .
-'        "valor": "Ano",' . "\n" .
-'        "evidencia": "Local onde a data foi encontrada"' . "\n" .
-'    },' . "\n" .
-'    "instituicao": {' . "\n" .
-'        "valor": "Instituição relacionada",' . "\n" .
-'        "evidencia": "Menções à instituição no documento"' . "\n" .
-'    },' . "\n" .
-'    "resumo": {' . "\n" .
-'        "valor": "Resumo do conteúdo (máx. 500 caracteres)",' . "\n" .
-'        "evidencia": "Seções principais que fundamentam o resumo"' . "\n" .
-'    },' . "\n" .
-'    "palavras_chave": {' . "\n" .
-'        "valor": ["palavras", "chave"],' . "\n" .
-'        "evidencia": "Seção de palavras-chave ou temas recorrentes identificados"' . "\n" .
-'    },' . "\n" .
-'    "area_conhecimento": {' . "\n" .
-'        "valor": "Área principal",' . "\n" .
-'        "evidencia": "Indicadores da área (terminologia, metodologia, referências)"' . "\n" .
-'    },' . "\n" .
-'    "idioma": {' . "\n" .
-'        "valor": "Idioma do documento",' . "\n" .
-'        "evidencia": "Idioma identificado no texto"' . "\n" .
-'    },' . "\n" .
-'    "referencias_principais": {' . "\n" .
-'        "valor": ["Referências importantes citadas"],' . "\n" .
-'        "evidencia": "Seção de referências ou citações no texto"' . "\n" .
-'    },' . "\n" .
-'    "metodologia": {' . "\n" .
-'        "valor": "Metodologia utilizada (se aplicável)",' . "\n" .
-'        "evidencia": "Seção de metodologia ou descrição dos métodos"' . "\n" .
-'    },' . "\n" .
-'    "observacoes": {' . "\n" .
-'        "valor": "Outras observações",' . "\n" .
-'        "evidencia": "Elementos adicionais notados no documento"' . "\n" .
-'    }' . "\n" .
-'}' . "\n\n" .
-'Responda APENAS com o JSON, sem texto adicional.';
     }
 
     /**
@@ -358,7 +198,7 @@ final class Tainacan_AI {
      * Initialize plugin components
      */
     public function init(): void {
-        $this->prune_legacy_option_keys();
+        $this->set_default_options();
 
         // Check if Tainacan is active
         if (!class_exists('\Tainacan\Repositories\Items')) {


### PR DESCRIPTION
- Removes separation between document and image specific prompts. Things shall be different according to each collection and metadata mapping;
- Creates the idea of Prompts templates to help defining some prompts. Extenders may filter and define new ones.

Closes #16 